### PR TITLE
fixing accumulate sufficient statistics to be compatible with hmmlearn

### DIFF
--- a/autohmm/tm.py
+++ b/autohmm/tm.py
@@ -410,7 +410,7 @@ class THMM(_BaseAUTOHMM):
                 posteriors = self._compute_posteriors(fwdlattice, bwdlattice)
                 self._accumulate_sufficient_statistics(
                     stats, X[i:j], framelogprob, posteriors, fwdlattice,
-                    bwdlattice, self.params)
+                    bwdlattice)
                 if self.n_tied > 0:
                     for u in range(self.n_unique):
                         cols = range(u*(self.n_chain),


### PR DESCRIPTION
Making call to `_accumulate_sufficient_statistics` compatible with latest version in hmmlearn, see commit here:
https://github.com/hmmlearn/hmmlearn/commit/e6b8676d09a123398acc45bf027ed51b54c7ae41#diff-3cc70fbb3fee013007da7e0f51206749
